### PR TITLE
Rename package to monte-vera

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "monete-vera",
+  "name": "monte-vera",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "monete-vera",
+      "name": "monte-vera",
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "monete-vera",
+  "name": "monte-vera",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Correct project metadata by renaming `monete-vera` to `monte-vera`
- Align package-lock metadata with new name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f5f4585883279e27e5727086f8d4