### PR TITLE
Fix schedules to use Argentina timezone

### DIFF
--- a/components/schedules-section.tsx
+++ b/components/schedules-section.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Clock, Calendar, ArrowRight } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -47,10 +47,25 @@ export default function SchedulesSection() {
 
   const currentSchedule = schedules[selectedRoute as keyof typeof schedules]
 
+  const argentinaTime = () =>
+    new Date(
+      new Date().toLocaleString('en-US', {
+        timeZone: 'America/Argentina/Buenos_Aires'
+      })
+    )
+
+  const [currentTime, setCurrentTime] = useState(argentinaTime())
+
+  useEffect(() => {
+    setCurrentTime(argentinaTime())
+
+    const interval = setInterval(() => setCurrentTime(argentinaTime()), 60_000)
+    return () => clearInterval(interval)
+  }, [])
+
   const getTimeStatus = (time: string) => {
-    const now = new Date()
-    const currentHour = now.getHours()
-    const currentMinute = now.getMinutes()
+    const currentHour = currentTime.getHours()
+    const currentMinute = currentTime.getMinutes()
     const [hour, minute] = time.split(':').map(Number)
     
     const currentTotalMinutes = currentHour * 60 + currentMinute

--- a/lib/bus-timing-service.ts
+++ b/lib/bus-timing-service.ts
@@ -39,11 +39,18 @@ export interface BusTimingRequest {
 }
 
 export class BusTimingService {
+  private static argentinaTime(): Date {
+    return new Date(
+      new Date().toLocaleString('en-US', {
+        timeZone: 'America/Argentina/Buenos_Aires'
+      })
+    )
+  }
   /**
    * Calculates the next bus arrival time at a specific stop
    */
   static calculateBusArrival({ routeId, stopId }: BusTimingRequest): BusArrivalResult {
-    const currentTime = new Date()
+    const currentTime = this.argentinaTime()
     const currentDayType = this.getCurrentDayType()
     
     // Get the schedule for today
@@ -60,7 +67,7 @@ export class BusTimingService {
     
     if (relevantBuses.length === 0) {
       return {
-        nextBusArrival: new Date(),
+        nextBusArrival: this.argentinaTime(),
         minutesToArrival: 0,
         currentTime,
         departureTime: '',
@@ -94,7 +101,7 @@ export class BusTimingService {
    * Determines the current day type for schedule lookup
    */
   static getCurrentDayType(): 'laborables' | 'sabados' | 'domingos' {
-    const today = new Date()
+    const today = this.argentinaTime()
     const dayOfWeek = today.getDay() // 0 = Sunday, 6 = Saturday
     const todayISO = today.toISOString().split('T')[0]
 


### PR DESCRIPTION
## Summary
- calculate current time using Buenos Aires timezone
- ensure bus timing service and schedules use Argentina time

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch fonts)


------
https://chatgpt.com/codex/tasks/task_e_68a753990aac832792fb57660b5c8ebc