### PR TITLE
feat: send contact form emails

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  const { nombre, email, telefono, asunto, mensaje } = await request.json()
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: 'web@montevera.com.ar',
+        to: ['info@montevera.com.ar'],
+        subject: asunto || 'Nuevo mensaje',
+        text: `Nombre: ${nombre}\nEmail: ${email}\nTeléfono: ${telefono}\n\n${mensaje}`,
+      }),
+    })
+
+    if (!res.ok) {
+      console.error('Failed to send email', await res.text())
+      return new NextResponse('Error sending email', { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error sending email', error)
+    return new NextResponse('Error sending email', { status: 500 })
+  }
+}

--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -30,21 +30,33 @@ export default function ContactSection() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsSubmitting(true)
-    
-    // Simular envío del formulario
-    setTimeout(() => {
-      setIsSubmitting(false)
-      setShowSuccess(true)
-      setFormData({
-        nombre: '',
-        email: '',
-        telefono: '',
-        asunto: '',
-        mensaje: ''
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
       })
-      
-      setTimeout(() => setShowSuccess(false), 5000)
-    }, 2000)
+
+      if (response.ok) {
+        setShowSuccess(true)
+        setFormData({
+          nombre: '',
+          email: '',
+          telefono: '',
+          asunto: '',
+          mensaje: ''
+        })
+        setTimeout(() => setShowSuccess(false), 5000)
+      } else {
+        console.error('Error al enviar el mensaje')
+      }
+    } catch (error) {
+      console.error('Error al enviar el mensaje', error)
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   const contactInfo = [


### PR DESCRIPTION
## Summary
- send contact form data to a new `/api/contact` endpoint
- deliver messages to info@montevera.com.ar via Resend

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75ad7b3c48327b653b82e8b10c221